### PR TITLE
Add LLM friendly JSON download API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ A simple, automatically updated site providing the latest download links for the
 
 **Live Site:** [downloadcursor.app](https://downloadcursor.app)
 
+### JSON API (LLM-friendly)
+
+- **Latest release (all platforms):** `https://downloadcursor.app/api/latest-download`
+- **Latest for a specific platform:** `https://downloadcursor.app/api/latest-download?platform=<key>`
+
+Supported platform keys include: `win32-x64-user`, `win32-x64-system`, `win32-arm64-user`, `win32-arm64-system`, `darwin-universal`, `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. Aliases accepted: `windows`, `windows-user`, `windows-system`, `mac`, `macos`, `macos-arm64`, `macos-x64`, `linux`.
+
+Example response (platform-filtered):
+
+```json
+{
+  "version": "<version>",
+  "date": "<date>",
+  "platform": "win32-x64-user",
+  "url": "https://downloads.cursor.com/.../CursorUserSetup-x64-<version>.exe",
+  "sizeBytes": <sizeBytes>,
+  "sha256": "<sha256>"
+}
+```
+
+For the full machine-readable history, you can also use `https://downloadcursor.app/version-history.json`.
+
 ![GitHub stars](https://img.shields.io/github/stars/accesstechnology-mike/cursor-downloads?style=social)
 ![Last commit](https://img.shields.io/github/last-commit/accesstechnology-mike/cursor-downloads)
 ![Update workflow](https://img.shields.io/github/actions/workflow/status/accesstechnology-mike/cursor-downloads/update.yml?branch=main)

--- a/api/latest-download.js
+++ b/api/latest-download.js
@@ -1,0 +1,91 @@
+const fs = require("fs");
+const path = require("path");
+
+function readVersionHistory() {
+  const historyPath = path.join(process.cwd(), "version-history.json");
+  const raw = fs.readFileSync(historyPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+function getLatestVersion(history) {
+  if (!history || !Array.isArray(history.versions) || history.versions.length === 0) {
+    return null;
+  }
+  return history.versions[0];
+}
+
+function normalizePlatformParam(param) {
+  if (!param) return null;
+  const p = String(param).toLowerCase();
+  // Accept canonical keys exactly as in version-history.json
+  // Also accept a few friendly aliases commonly used by users/tools
+  const aliases = {
+    windows: "win32-x64-user",
+    "windows-user": "win32-x64-user",
+    "windows-system": "win32-x64-system",
+    mac: "darwin-universal",
+    macos: "darwin-universal",
+    "macos-arm64": "darwin-arm64",
+    "macos-x64": "darwin-x64",
+    linux: "linux-x64",
+    "linux-x64": "linux-x64",
+    "linux-arm64": "linux-arm64",
+  };
+  return aliases[p] || param; // if user passed canonical key, keep as-is
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store, must-revalidate");
+
+  try {
+    const history = readVersionHistory();
+    const latest = getLatestVersion(history);
+
+    if (!latest) {
+      return res.status(500).json({ error: "No version data available" });
+    }
+
+    const urlParams = new URL(req.url, `http://${req.headers.host}`);
+    const platformParam = normalizePlatformParam(urlParams.searchParams.get("platform"));
+
+    // If a platform is specified, return a minimal, LLM-friendly JSON for that platform
+    if (platformParam) {
+      const url = latest.platforms?.[platformParam];
+      const details = latest.platformDetails?.[platformParam];
+
+      if (!url) {
+        const available = Object.keys(latest.platforms || {});
+        return res.status(404).json({
+          error: "Unknown or unavailable platform",
+          platform: platformParam,
+          availablePlatforms: available,
+        });
+      }
+
+      return res.status(200).json({
+        version: latest.version,
+        date: latest.date,
+        platform: platformParam,
+        url,
+        sizeBytes: details?.sizeBytes ?? null,
+        sha256: details?.sha256 ?? null,
+      });
+    }
+
+    // Otherwise return concise metadata for the latest release
+    return res.status(200).json({
+      version: latest.version,
+      date: latest.date,
+      platforms: latest.platforms || {},
+      platformDetails: latest.platformDetails || {},
+    });
+  } catch (err) {
+    console.error("/api/latest-download error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};

--- a/index.html
+++ b/index.html
@@ -2693,6 +2693,9 @@
             >GitHub</a
           >.
         </div>
+        <div style="margin-top: 0.5rem; color: var(--text-secondary); font-size: 0.9rem;">
+          JSON API: <code>/api/latest-download</code> (optionally <code>?platform=&lt;key&gt;</code>)
+        </div>
       </div>
       <div
         style="

--- a/scripts/update-links.ts
+++ b/scripts/update-links.ts
@@ -763,10 +763,10 @@ A simple, automatically updated site providing the latest download links for the
 
 ### JSON API (LLM-friendly)
 
-- **Latest release (all platforms):** `${liveSiteUrl}/api/latest-download`
-- **Latest for a specific platform:** `${liveSiteUrl}/api/latest-download?platform=<key>`
+- **Latest release (all platforms):** \`${liveSiteUrl}/api/latest-download\`
+- **Latest for a specific platform:** \`${liveSiteUrl}/api/latest-download?platform=<key>\`
 
-Supported platform keys include: `win32-x64-user`, `win32-x64-system`, `win32-arm64-user`, `win32-arm64-system`, `darwin-universal`, `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. Aliases accepted: `windows`, `windows-user`, `windows-system`, `mac`, `macos`, `macos-arm64`, `macos-x64`, `linux`.
+Supported platform keys include: \`win32-x64-user\`, \`win32-x64-system\`, \`win32-arm64-user\`, \`win32-arm64-system\`, \`darwin-universal\`, \`darwin-arm64\`, \`darwin-x64\`, \`linux-x64\`, \`linux-arm64\`. Aliases accepted: \`windows\`, \`windows-user\`, \`windows-system\`, \`mac\`, \`macos\`, \`macos-arm64\`, \`macos-x64\`, \`linux\`.
 
 Example response (platform-filtered):
 
@@ -781,7 +781,7 @@ Example response (platform-filtered):
 }
 \`\`\`
 
-For the full machine-readable history, you can also use `${liveSiteUrl}/version-history.json`.
+For the full machine-readable history, you can also use \`${liveSiteUrl}/version-history.json\`.
 
 ![GitHub stars](https://img.shields.io/github/stars/accesstechnology-mike/cursor-downloads?style=social)
 ![Last commit](https://img.shields.io/github/last-commit/accesstechnology-mike/cursor-downloads)

--- a/scripts/update-links.ts
+++ b/scripts/update-links.ts
@@ -761,6 +761,28 @@ A simple, automatically updated site providing the latest download links for the
 
 **Live Site:** [${liveSiteUrl.replace("https://", "")}](${liveSiteUrl})
 
+### JSON API (LLM-friendly)
+
+- **Latest release (all platforms):** `${liveSiteUrl}/api/latest-download`
+- **Latest for a specific platform:** `${liveSiteUrl}/api/latest-download?platform=<key>`
+
+Supported platform keys include: `win32-x64-user`, `win32-x64-system`, `win32-arm64-user`, `win32-arm64-system`, `darwin-universal`, `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. Aliases accepted: `windows`, `windows-user`, `windows-system`, `mac`, `macos`, `macos-arm64`, `macos-x64`, `linux`.
+
+Example response (platform-filtered):
+
+\`\`\`json
+{
+  "version": "${latestEntry.version}",
+  "date": "${latestEntry.date}",
+  "platform": "win32-x64-user",
+  "url": "${platforms["win32-x64-user"] || "https://downloads.cursor.com/.../CursorUserSetup-x64.exe"}",
+  "sizeBytes": ${latestDetails["win32-x64-user"]?.sizeBytes ?? 0},
+  "sha256": "${latestDetails["win32-x64-user"]?.sha256 || "<sha256>"}"
+}
+\`\`\`
+
+For the full machine-readable history, you can also use `${liveSiteUrl}/version-history.json`.
+
 ![GitHub stars](https://img.shields.io/github/stars/accesstechnology-mike/cursor-downloads?style=social)
 ![Last commit](https://img.shields.io/github/last-commit/accesstechnology-mike/cursor-downloads)
 ![Update workflow](https://img.shields.io/github/actions/workflow/status/accesstechnology-mike/cursor-downloads/update.yml?branch=main)

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,14 @@
       }
     },
     {
+      "src": "/api/latest-download",
+      "dest": "/api/latest-download.js",
+      "headers": {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store, must-revalidate"
+      }
+    },
+    {
       "src": "/(.*\\.(js|css|json|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot))",
       "dest": "/$1"
     },


### PR DESCRIPTION
Add a new LLM-friendly JSON API endpoint to programmatically retrieve the latest download links, with documentation updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-4530e61b-2b30-4925-aa67-c25308100754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4530e61b-2b30-4925-aa67-c25308100754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

